### PR TITLE
Fix kernel density update and update project version to 1.6.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Create conda environment and build
       shell: bash -l {0}
       run: |
-        conda create -n surfatt -c conda-forge openmpi cxx-compiler fortran-compiler cmake hdf5 -y
+        conda create -n surfatt -c conda-forge openmpi cxx-compiler fortran-compiler zlib cmake hdf5 -y
         conda activate surfatt
         mkdir build && cd build
         cmake .. && make -j4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 set(CMAKE_PROJECT_NAME "SurfATT")
-project(${CMAKE_PROJECT_NAME} VERSION 1.6.1 LANGUAGES Fortran CXX)
+project(${CMAKE_PROJECT_NAME} VERSION 1.6.2 LANGUAGES Fortran CXX)
 
 # set the version number and git commit hash
 execute_process(

--- a/src/acqui.f90
+++ b/src/acqui.f90
@@ -212,7 +212,7 @@ contains
             this%ker(1,:,:,i) = this%ker(1,:,:,i) - this%adj_s(ip,:,:) * this%sen_vsRc(ip,:,:,i)
             this%ker_density(1,:,:,i) = this%ker_density(1,:,:,i) - this%adj_density(ip,:,:) * this%sen_vsRc(ip,:,:,i)
             this%ker(2,:,:,i) = this%ker(2,:,:,i) - this%adj_s(ip,:,:) * this%sen_vpRc(ip,:,:,i)
-            this%ker_density(2,:,:,i) = this%ker_density(2,:,:,i) - this%adj_density(ip,:,:) * this%sen_vpRc(ip,:,:,i)
+            this%ker_density(2,:,:,i) = this%ker_density(2,:,:,i) - this%adj_density(ip,:,:) * this%sen_vsRc(ip,:,:,i)
             if (.not. ap%inversion%rho_scaling) then
               this%ker(3,:,:,i) = this%ker(3,:,:,i) - this%adj_s(ip,:,:) * this%sen_rhoRc(ip,:,:,i)
               this%ker_density(3,:,:,i) = this%ker_density(3,:,:,i) - this%adj_density(ip,:,:) * this%sen_rhoRc(ip,:,:,i)


### PR DESCRIPTION
This pull request includes a bug fix to the kernel density calculation, a dependency update in the build workflow, and a version bump for the project. The most important changes are summarized below:

### Bug Fixes

* Corrected a calculation in the `combine_kernels` subroutine in `src/acqui.f90` so that `ker_density(2,:,:,:)` now uses `sen_vsRc` instead of `sen_vpRc`, ensuring the correct sensitivity kernel is applied for density updates.

### Build and Dependency Updates

* Added `zlib` to the list of dependencies in the Conda environment setup in `.github/workflows/build.yml` to ensure all required libraries are available during the build process.

### Versioning

* Updated the project version in `CMakeLists.txt` from `1.6.1` to `1.6.2` to reflect the new changes and bug fixes.